### PR TITLE
Update picker.jsx

### DIFF
--- a/src/picker.jsx
+++ b/src/picker.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Emoji from './emoji';
 import Modifiers from './modifiers';
-import strategy from '../node_modules/emojione/emoji.json';
+import strategy from 'emojione/emoji.json';
 import emojione from 'emojione';
 import store from 'store';
 import {throttle, each, map, compact} from 'lodash';


### PR DESCRIPTION
why should we specific the emojione node_modules folder here? I need to install both emojione and emojione_picker, so npm will not install emojione in emojione_picker node_modules folder, but will use the one my project node_modules/emojione.