### PR TITLE
Shallow compares to prevent unnecessary renders

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "emojione": "^2.2.6",
     "lodash": "^4.15.0",
+    "react-addons-shallow-compare": "15.4.2",
     "store": "^1.3.20"
   },
   "peerDependencies": {

--- a/src/picker.jsx
+++ b/src/picker.jsx
@@ -8,6 +8,7 @@ import throttle from 'lodash/throttle';
 import each from 'lodash/each';
 import map from 'lodash/map';
 import compact from 'lodash/compact';
+import shallowCompare from 'react-addons-shallow-compare';
 
 const Picker = React.createClass({
     propTypes: {
@@ -102,6 +103,10 @@ const Picker = React.createClass({
           }
         }, 0);
       }
+    },
+
+    shouldComponentUpdate: function(nextProps, nextState) {
+      return shallowCompare(this, nextProps, nextState);
     },
 
     updateSearchTerm: function() {


### PR DESCRIPTION
As issue #38 I had problems using this inside a component which rerenders frequently. Added the fix that was suggested in the issue which works in my case.