### PR TITLE
Escape regex metacharcters when constructing search term RegExp from …

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "dependencies": {
     "emojione": "^2.2.6",
+    "escape-string-regexp": "^1.0.5",
     "lodash": "^4.15.0",
     "react-virtualized": "^8.11.4",
     "store": "^1.3.20"

--- a/src/utils/createRowsSelector.js
+++ b/src/utils/createRowsSelector.js
@@ -1,10 +1,11 @@
+import escape from 'escape-string-regexp';
 import chunk from 'lodash/chunk';
 import map from 'lodash/map';
 import values from 'lodash/values';
 
 function rowsSelector(categories, emojisByCategory, modifier, search, term) {
   const findEmojiVariant = emojis => modifier && emojis[modifier] ? emojis[modifier] : emojis[0];
-  const searchTermRegExp = new RegExp(`^(?:.* +)*${term}`, 'i');
+  const searchTermRegExp = new RegExp(`^(?:.* +)*${escape(term)}`, 'i');
   const keywordMatchesSearchTerm = keyword => searchTermRegExp.test(keyword);
   const emojiMatchesSearchTerm = emoji => emoji.keywords.concat(emoji.name).some(keywordMatchesSearchTerm);
 


### PR DESCRIPTION
…user input

Without escaping, user input such as "[" or "\*" trigger an uncaught SyntaxError: "Invalid regular expression: /^(?:.* +)*[/: Unterminated character class"