### PR TITLE
Also include shortname on click

### DIFF
--- a/src/emoji.jsx
+++ b/src/emoji.jsx
@@ -33,6 +33,7 @@ export default class Emoji extends Component {
       ev,
       pick(
         this.props,
+        "shortname",
         "aliases",
         "aliases_ascii",
         "category",


### PR DESCRIPTION
In latest release shortname is not includes in the click handler anymore, I've added that in this pull request.