### PR TITLE
Fix CircleCI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
   "devDependencies": {
     "babel-cli": "^6.7.5",
     "babel-eslint": "^7.1.1",
+    "babel-jest": "^18.0.0",
+    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",


### PR DESCRIPTION
I saw that CircleCI builds have failed against the last few commits. Jest was failing with a SyntaxError on the `import` keyword, to it seems the babel transpiling was not working.

Hopefully this fixes it - it adds two dev dependencies required by jest as documented at http://facebook.github.io/jest/docs/getting-started.html#using-babel.

* babel-jest
* babel-polyfill