### PR TITLE
Use prop-types package instead of React built-in PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "http-server": "^0.9.0",
     "jest": "^18.1.0",
     "prettier": "^0.16.0",
+    "prop-types": "^15.5.6",
     "react": "^15.4.2",
     "react-addons-perf": "^15.4.2",
     "react-addons-shallow-compare": "^15.0.0",

--- a/src/categories.jsx
+++ b/src/categories.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { AutoSizer, List } from "react-virtualized";
 import findIndex from "lodash/findIndex";
 import throttle from "lodash/throttle";

--- a/src/category-header.jsx
+++ b/src/category-header.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import shallowCompare from "react-addons-shallow-compare";
 
 export default class CategoryHeader extends Component {

--- a/src/emoji-row.jsx
+++ b/src/emoji-row.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import shallowCompare from "react-addons-shallow-compare";
 import Emoji from "./emoji";
 

--- a/src/emoji.jsx
+++ b/src/emoji.jsx
@@ -1,15 +1,16 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import pick from "lodash/pick";
 import emojione from "emojione";
 
 export default class Emoji extends Component {
   static propTypes = {
-    ariaLabel: React.PropTypes.string,
-    name: React.PropTypes.string,
-    onSelect: React.PropTypes.func.isRequired,
-    shortname: React.PropTypes.string,
-    title: React.PropTypes.string,
-    role: React.PropTypes.string
+    ariaLabel: PropTypes.string,
+    name: PropTypes.string,
+    onSelect: PropTypes.func.isRequired,
+    shortname: PropTypes.string,
+    title: PropTypes.string,
+    role: PropTypes.string
   };
 
   shouldComponentUpdate(nextProps) {

--- a/src/modifier.jsx
+++ b/src/modifier.jsx
@@ -1,11 +1,12 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 export default class Modifier extends Component {
   static propTypes = {
-    onClick: React.PropTypes.func.isRequired,
-    active: React.PropTypes.bool,
-    type: React.PropTypes.string.isRequired,
-    hex: React.PropTypes.string.isRequired
+    onClick: PropTypes.func.isRequired,
+    active: PropTypes.bool,
+    type: PropTypes.string.isRequired,
+    hex: PropTypes.string.isRequired
   };
 
   _handleClick = ev => {

--- a/src/modifiers.jsx
+++ b/src/modifiers.jsx
@@ -1,12 +1,13 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import map from "lodash/map";
 import Modifier from "./modifier";
 
 export default class Modifiers extends Component {
   static propTypes = {
-    onChange: React.PropTypes.func.isRequired,
-    modifiers: React.PropTypes.object,
-    active: React.PropTypes.string
+    onChange: PropTypes.func.isRequired,
+    modifiers: PropTypes.object,
+    active: PropTypes.string
   };
 
   static defaultProps = {

--- a/src/picker.jsx
+++ b/src/picker.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import emojione from "emojione";
 import store from "store";
 import each from "lodash/each";
@@ -13,19 +14,19 @@ import { defaultCategories } from "./constants";
 
 export default class Picker extends Component {
   static propTypes = {
-    emojione: React.PropTypes.shape({
-      imageType: React.PropTypes.string,
-      sprites: React.PropTypes.bool,
-      imagePathSVGSprites: React.PropTypes.string
+    emojione: PropTypes.shape({
+      imageType: PropTypes.string,
+      sprites: PropTypes.bool,
+      imagePathSVGSprites: PropTypes.string
     }),
-    search: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string
+    search: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string
     ]),
-    searchPlaceholder: React.PropTypes.string,
-    className: React.PropTypes.string,
-    onChange: React.PropTypes.func.isRequired,
-    categories: React.PropTypes.object
+    searchPlaceholder: PropTypes.string,
+    className: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    categories: PropTypes.object
   };
 
   static defaultProps = {


### PR DESCRIPTION
Accessing PropTypes via the main React package is deprecated. 
https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html