### PR TITLE
Selectively import from react-virtualized to reduce bundle size

### DIFF
--- a/src/categories.jsx
+++ b/src/categories.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { AutoSizer, List } from "react-virtualized";
+import AutoSizer from "react-virtualized/dist/commonjs/AutoSizer";
+import List from "react-virtualized/dist/commonjs/List";
 import findIndex from "lodash/findIndex";
 import throttle from "lodash/throttle";
 import CategoryHeader from "./category-header";


### PR DESCRIPTION
This PR reduces the bundle size of `emojione-picker` from 215524 bytes (216kB) min+gz to 149830 bytes (150kB) min+gz, a reduction of 30%. (I measured using `npm run prepublish` then `browserify . | uglifyjs -mc | gzip -c | wc -c`.)

This trick is described in [`react-virtualized`'s documentation](https://github.com/bvaughn/react-virtualized#getting-started).