### PR TITLE
Upgrade store to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react": ">=0.14.0",
     "react-addons-shallow-compare": ">=0.14.0",
     "react-virtualized": "^9.7.4",
-    "store": "^1.3.20"
+    "store": "^2.0.4"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3985,9 +3985,9 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-store@^1.3.20:
-  version "1.3.20"
-  resolved "https://registry.yarnpkg.com/store/-/store-1.3.20.tgz#13ea7e3fb2d6c239868265d686b1d84e99c5be3e"
+store@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/store/-/store-2.0.4.tgz#6c6819602a5497166ade85db2442cc64ebcc5761"
 
 stream-browserify@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
The backward compatibility is kept even with store v2, so there is no problem as it is.

> Store.js version 2 is a full revamp with pluggable storage (it will automatically fall back to one that works in every scenario by default), pluggable extra functionality (like [expirations](https://github.com/marcuswestin/store.js/blob/v2.0.4/plugins/expire.js), [default values](https://github.com/marcuswestin/store.js/blob/v2.0.4/plugins/defaults.js), common [array/object operations](https://github.com/marcuswestin/store.js/blob/v2.0.4/plugins/operations.js), etc), and fully cross-browser automatic testing using saucelabs.com.

cite: https://github.com/marcuswestin/store.js/tree/v2.0.4#user-content-version-20

Future expansion becomes easy.
